### PR TITLE
Fix Bright Nights path handling and add tests

### DIFF
--- a/cdda_launcher.py
+++ b/cdda_launcher.py
@@ -152,6 +152,15 @@ class CDDALauncher(ctk.CTk):
         except IOError:
             pass  # If we can't save, just continue
 
+    def get_game_path(self, version_type):
+        """Return the filesystem path for a given game version."""
+        if version_type == "experimental":
+            return self.experimental_path
+        elif version_type == "stable":
+            return self.stable_path
+        else:
+            return self.bn_path
+
     def _create_ui(self):
         # Header with game selector
         header_frame = ctk.CTkFrame(self)
@@ -657,7 +666,7 @@ class CDDALauncher(ctk.CTk):
                     if not app_name:
                         raise Exception("Could not find .app in mounted DMG")
                     
-                    target_path = self.experimental_path if version_type == "experimental" else self.stable_path
+                    target_path = self.get_game_path(version_type)
                     
                     # Backup important user data
                     save_data = {}
@@ -725,7 +734,7 @@ class CDDALauncher(ctk.CTk):
         thread.start()
 
     def launch_game(self, version_type):
-        path = self.experimental_path if version_type == "experimental" else self.stable_path
+        path = self.get_game_path(version_type)
         
         if not os.path.exists(path):
             self.status_text.set(f"No {version_type} version installed")
@@ -741,7 +750,7 @@ class CDDALauncher(ctk.CTk):
         self.status_text.set(f"Launching {version_type} version...")
 
     def open_folder(self, version_type):
-        path = self.experimental_path if version_type == "experimental" else self.stable_path
+        path = self.get_game_path(version_type)
         subprocess.Popen(["open", path])
 
     def on_closing(self):

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,0 +1,70 @@
+import unittest
+from unittest.mock import patch, MagicMock
+
+import os
+import sys
+
+# Fake customtkinter to avoid dependency on GUI library during tests
+class Dummy:
+    def __init__(self, *a, **k):
+        pass
+    def __getattr__(self, name):
+        return Dummy
+
+dummy_module = MagicMock()
+dummy_module.CTk = Dummy
+dummy_module.CTkFrame = Dummy
+dummy_module.CTkButton = Dummy
+dummy_module.CTkLabel = Dummy
+dummy_module.CTkProgressBar = Dummy
+dummy_module.CTkTextbox = Dummy
+dummy_module.CTkFont = Dummy
+dummy_module.StringVar = Dummy
+dummy_module.DoubleVar = Dummy
+dummy_module.set_appearance_mode = lambda *a, **k: None
+sys.modules.setdefault('customtkinter', dummy_module)
+sys.modules.setdefault('requests', MagicMock())
+sys.modules.setdefault('tqdm', MagicMock())
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+import cdda_launcher
+
+class BaseLauncher(cdda_launcher.CDDALauncher):
+    def _create_ui(self):
+        # Avoid creating GUI during tests
+        pass
+
+    def check_versions(self):
+        # Skip network access
+        pass
+
+class PathTests(unittest.TestCase):
+    def setUp(self):
+        with patch.object(cdda_launcher, 'SingleInstance', new=MagicMock()):
+            self.launcher = BaseLauncher()
+        # use deterministic paths
+        self.launcher.experimental_path = '/tmp/exp'
+        self.launcher.stable_path = '/tmp/stable'
+        self.launcher.bn_path = '/tmp/bn'
+
+    def test_get_game_path(self):
+        self.assertEqual(self.launcher.get_game_path('experimental'), '/tmp/exp')
+        self.assertEqual(self.launcher.get_game_path('stable'), '/tmp/stable')
+        self.assertEqual(self.launcher.get_game_path('bn'), '/tmp/bn')
+
+    @patch('subprocess.Popen')
+    def test_open_folder_bn(self, popen):
+        self.launcher.open_folder('bn')
+        popen.assert_called_once_with(['open', '/tmp/bn'])
+
+    @patch('subprocess.Popen')
+    @patch('os.listdir')
+    @patch('os.path.exists')
+    def test_launch_game_bn(self, exists, listdir, popen):
+        exists.return_value = True
+        listdir.return_value = ['Cataclysm.app']
+        self.launcher.launch_game('bn')
+        popen.assert_called_once_with(['open', '/tmp/bn/Cataclysm.app'])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- ensure Bright Nights uses the correct install path
- add a helper for returning the game path
- test game path selection, open_folder and launch_game for BN

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685703815f688332846bd1e7b5bb05f8